### PR TITLE
Metric integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ A couple notes with this approach:
 - Other docker commands that you might need: `docker ps -a` lists all
   containers, including ones that you've stopped; to clean these, run
   `docker container prune`.
-- If your using WSL, it's not very smart about paths; you need to use an
+- If you're using WSL, it's not very smart about paths; you need to use an
   absolute path in place of `"$(pwd)"` that actually references drive letters,
   like `/mnt/d/Repositories/traveler-integrated`
 

--- a/database.py
+++ b/database.py
@@ -608,16 +608,10 @@ class Database:
             # Connect to most recent interval with the parent GUID
             parentGuid = intervalObj.get('Parent GUID', intervalObj['enter'].get('Parent GUID', None))
 
-            problemIds = ['325', '826', '1082', '68']
-            if intervalObj['intervalId'] in problemIds:
-                print(intervalObj['intervalId'], guid, guid in guids, parentGuid, parentGuid in guids)
-
             if parentGuid is not None and parentGuid in guids:
                 foundPrior = False
                 for parentIntervalId in reversed(guids[parentGuid]):
                     parentInterval = intervals[parentIntervalId]
-                    if intervalObj['intervalId'] == '826':
-                        print(parentInterval['enter']['Timestamp'], parentInterval['exit']['Timestamp'], intervalObj['enter']['Timestamp'])
                     if parentInterval['enter']['Timestamp'] <= intervalObj['enter']['Timestamp']:
                         foundPrior = True
                         intervalCount += 1

--- a/database.py
+++ b/database.py
@@ -597,16 +597,27 @@ class Database:
 
             # Parent GUIDs refer to the one in the enter event, not the leave event
             guid = intervalObj.get('GUID', intervalObj['enter'].get('GUID', None))
+
             if guid is None:
                 missingCount += 1
-                continue
+            else:
+                if not guid in guids:
+                    guids[guid] = []
+                guids[guid] = guids[guid] + [intervalId]
 
             # Connect to most recent interval with the parent GUID
             parentGuid = intervalObj.get('Parent GUID', intervalObj['enter'].get('Parent GUID', None))
+
+            problemIds = ['325', '826', '1082', '68']
+            if intervalObj['intervalId'] in problemIds:
+                print(intervalObj['intervalId'], guid, guid in guids, parentGuid, parentGuid in guids)
+
             if parentGuid is not None and parentGuid in guids:
                 foundPrior = False
                 for parentIntervalId in reversed(guids[parentGuid]):
                     parentInterval = intervals[parentIntervalId]
+                    if intervalObj['intervalId'] == '826':
+                        print(parentInterval['enter']['Timestamp'], parentInterval['exit']['Timestamp'], intervalObj['enter']['Timestamp'])
                     if parentInterval['enter']['Timestamp'] <= intervalObj['enter']['Timestamp']:
                         foundPrior = True
                         intervalCount += 1
@@ -633,13 +644,6 @@ class Database:
                     missingCount += 1
             else:
                 missingCount += 1
-
-            # Store this interval by its leave GUID
-            guid = intervalObj.get('GUID', intervalObj['leave'].get('GUID', None))
-            if guid is not None:
-                if guid not in guids:
-                    guids[guid] = []
-                guids[guid] = guids[guid] + [intervalId]
 
             if (missingCount + intervalCount) % 2500 == 0:
                 await log('.', end='')

--- a/database.py
+++ b/database.py
@@ -12,7 +12,7 @@ from intervaltree import Interval, IntervalTree #pylint: disable=import-error
 # Possible files / metadata structures that we create / open / update
 shelves = ['meta', 'primitives', 'primitiveLinks', 'intervals', 'guids', 'events']
 requiredShelves = ['meta', 'primitives', 'primitiveLinks']
-pickles = ['intervalIndexes', 'metricIndexes', 'trees', 'physl', 'python', 'cpp']
+pickles = ['intervalIndexes', 'trees', 'physl', 'python', 'cpp']
 requiredMetaLists = ['sourceFiles']
 requiredPickleDicts = ['trees']
 
@@ -409,7 +409,6 @@ class Database:
             'locations': {},
             'both': {}
         }
-        metricIndexes = self.datasets[label]['metricIndexes'] = {}
         guids = self.datasets[label]['guids'] = shelve.open(os.path.join(labelDir, 'guids.shelf'))
         self.datasets[label]['meta']['storedEvents'] = storeEvents
         if storeEvents:
@@ -421,6 +420,9 @@ class Database:
         await log('Parsing OTF2 events (.=2500 events)')
         newR = seenR = 0
         currentEvent = None
+        includedMetrics = 0
+        skippedMetricsForMissingPrior = 0
+        skippedMetricsForMismatch = 0
 
         for line in file:
             eventLineMatch = eventLineParser.match(line)
@@ -436,12 +438,14 @@ class Database:
                 timestamp = int(metricLineMatch.group(2))
                 metricType = metricLineMatch.group(3)
                 value = int(float(metricLineMatch.group(4)))
-                if location not in metricIndexes:
-                    metricIndexes[location] = {}
-                if metricType not in metricIndexes[location]:
-                    metricIndexes[location][metricType] = IntervalTree()
-                miv = Interval(timestamp, timestamp+1, value)
-                metricIndexes[location][metricType].add(miv)
+
+                if currentEvent is None:
+                    skippedMetricsForMissingPrior += 1
+                elif currentEvent['Timestamp'] != timestamp or currentEvent['Location'] != location:
+                    skippedMetricsForMismatch += 1
+                else:
+                    includedMetrics += 1
+                    currentEvent['metrics'][metricType] = value
             elif eventLineMatch is not None:
                 # This is the beginning of a new event; process the previous one
                 if currentEvent is not None:
@@ -455,7 +459,7 @@ class Database:
                     # Add to primitive / guid counts
                     newR += counts[0]
                     seenR += counts[1]
-                currentEvent = {}
+                currentEvent = {'metrics': {}}
                 currentEvent['Event'] = eventLineMatch.group(1)
                 currentEvent['Location'] = eventLineMatch.group(2)
                 currentEvent['Timestamp'] = int(eventLineMatch.group(3))
@@ -478,6 +482,7 @@ class Database:
         await log('')
         await log('Finished processing %i events' % numEvents)
         await log('New primitives: %d, References to existing primitives: %d' % (newR, seenR))
+        await log('Metrics included: %d; skpped for no prior ENTER: %d; skipped for mismatch: %d' % (includedMetrics, skippedMetricsForMissingPrior, skippedMetricsForMismatch))
 
         # Now that we've seen all the locations, store that list in our metadata
         locationNames = self.datasets[label]['meta']['locationNames'] = sorted(self.sortedEventsByLocation.keys())

--- a/database.py
+++ b/database.py
@@ -607,7 +607,7 @@ class Database:
                 foundPrior = False
                 for parentIntervalId in reversed(guids[parentGuid]):
                     parentInterval = intervals[parentIntervalId]
-                    if parentInterval['leave']['Timestamp'] <= intervalObj['enter']['Timestamp']:
+                    if parentInterval['enter']['Timestamp'] <= intervalObj['enter']['Timestamp']:
                         foundPrior = True
                         intervalCount += 1
                         # Store metadata about the most recent interval
@@ -635,9 +635,11 @@ class Database:
                 missingCount += 1
 
             # Store this interval by its leave GUID
-            if guid not in guids:
-                guids[guid] = []
-            guids[guid] = guids[guid] + [intervalId]
+            guid = intervalObj.get('GUID', intervalObj['leave'].get('GUID', None))
+            if guid is not None:
+                if guid not in guids:
+                    guids[guid] = []
+                guids[guid] = guids[guid] + [intervalId]
 
             if (missingCount + intervalCount) % 2500 == 0:
                 await log('.', end='')

--- a/serve.py
+++ b/serve.py
@@ -280,6 +280,8 @@ def intervalTrace(label: str, intervalId: str, begin: float = None, end: float =
 
         if 'lastParentInterval' not in intervalObj:
             # We reached the beginning with no intersections; terminate early
+            if intervalObj['enter']['Timestamp'] <= end and intervalObj['leave']['Timestamp'] >= begin:
+                yield '"%s"' % intervalObj['intervalId']
             yield ']'
             return
         if targetInterval != intervalObj:

--- a/serve.py
+++ b/serve.py
@@ -325,6 +325,14 @@ def intervalTrace(label: str, intervalId: str, begin: float = None, end: float =
         yield ']'
     return StreamingResponse(intervalIdGenerator(), media_type='application/json')
 
+@app.get('/datasets/{label}/guids/{guid}/intervalIds')
+def guidIntervalIds(label: str, guid: str):
+    checkDatasetExistence(label)
+    checkDatasetHasIntervals(label)
+    if guid not in db[label]['guids']:
+        raise HTTPException(status_code=404, detail='GUID %s not found' % guid)
+    return db[label]['guids'][guid]
+
 if __name__ == '__main__':
     asyncio.get_event_loop().run_until_complete(db.load())
     uvicorn.run(app, host='0.0.0.0')

--- a/serve.py
+++ b/serve.py
@@ -278,12 +278,6 @@ def intervalTrace(label: str, intervalId: str, begin: float = None, end: float =
             parentId = intervalObj['lastParentInterval']['id']
             intervalObj = db[label]['intervals'][parentId]
 
-        if 'lastParentInterval' not in intervalObj:
-            # We reached the beginning with no intersections; terminate early
-            if intervalObj['enter']['Timestamp'] <= end and intervalObj['leave']['Timestamp'] >= begin:
-                yield '"%s"' % intervalObj['intervalId']
-            yield ']'
-            return
         if targetInterval != intervalObj:
             # Because the target interval isn't in the query window, yield some
             # metadata about the interval beyond the end boundary, so the client

--- a/serve.py
+++ b/serve.py
@@ -253,7 +253,7 @@ def intervals(label: str, begin: float = None, end: float = None):
         yield ']'
     return StreamingResponse(intervalGenerator(), media_type='application/json')
 
-@app.get('/datasets/{label}/intervals/{intervalId}/Trace')
+@app.get('/datasets/{label}/intervals/{intervalId}/trace')
 def intervalTrace(label: str, intervalId: str, begin: float = None, end: float = None):
     # This streams back a list of string IDs, as well as two special metadata
     # objects for drawing lines to the left and right of the queried range when
@@ -268,63 +268,58 @@ def intervalTrace(label: str, intervalId: str, begin: float = None, end: float =
 
     def intervalIdGenerator():
         yield '['
-        targetInterval = intervalObj = oneBeyondRight = db[label]['itervals'][intervalId]
+        targetInterval = intervalObj = db[label]['intervals'][intervalId]
+        lastInterval = None
 
-        while intervalObj is not None:
-            # Until we yield the first interval, keep track of whatever to its
-            # right, beyond the queried window
-            if oneBeyondRight is not None and intervalObj['enter']['Timestamp'] <= end:
-                if oneBeyondRight == targetInterval:
-                    # The target interval is within the queried window; we can just send
-                    # that ID back directly instead of metadata
-                    yield '"%s"' % targetInterval['intervalId']
-                else:
-                    # Before sending the first interval within the queried
-                    # window, yield some metadata about the interval beyond the
-                    # end boundary, so the client can draw lines beyond the
-                    # window (and won't need access to the interval beyond the
-                    # window itself)
-                    yield json.dumps({
-                        'type': 'beyondRight',
-                        'id': oneBeyondRight['intervalId'],
-                        'location': oneBeyondRight['Location'],
-                        'beginTimestamp': oneBeyondRight['enter']['Timestamp']
-                    })
-                # Don't track whatever is to the right anymore
-                oneBeyondRight = None
+        # First phase: from the targetInterval, step backward until we encounter
+        # an interval in the queried range (or we run out of intervals)
+        while 'lastParentInterval' in intervalObj and intervalObj['enter']['Timestamp'] > end:
+            lastInterval = intervalObj
+            parentId = intervalObj['lastParentInterval']['id']
+            intervalObj = db[label]['intervals'][parentId]
 
-            # Yield the current interval (corner case: if it's the same as the
-            # target interval, don't yield it twice)
+        if 'lastParentInterval' not in intervalObj:
+            # We reached the beginning with no intersections; terminate early
+            yield ']'
+            return
+        if targetInterval != intervalObj:
+            # Because the target interval isn't in the query window, yield some
+            # metadata about the interval beyond the end boundary, so the client
+            # can draw lines beyond the window (and won't need access to the
+            # interval beyond the window itself)
+            yield json.dumps({
+                'type': 'beyondRight',
+                'id': lastInterval['intervalId'],
+                'location': lastInterval['Location'],
+                'beginTimestamp': lastInterval['enter']['Timestamp']
+            })
+
+        # Second phase: yield interval ids until we encounter an interval beyond
+        # the queried range (or we run out)
+        while 'lastParentInterval' in intervalObj and intervalObj['leave']['Timestamp'] >= begin:
             if intervalObj != targetInterval:
-                yield ',"%s"' % intervalObj['intervalId']
+                yield ','
+            yield '"%s"' % intervalObj['intervalId']
+            lastInterval = intervalObj
+            parentId = intervalObj['lastParentInterval']['id']
+            intervalObj = db[label]['intervals'][parentId]
 
-            # Point oneBeyondRight to the current interval if we haven't found
-            # one in the queried range yet, and shift intervalObj to its parent
-            if 'lastParentInterval' in intervalObj:
-                if oneBeyondRight is not None:
-                    oneBeyondRight = intervalObj
-                prevId = intervalObj['lastParentInterval']['id']
-                intervalObj = db[label]['intervals'][prevId]
-
-                # Stop yielding intervals if we went to the left of the queried
-                # range
-                if intervalObj['leave']['Timestamp'] < begin:
-                    break
-            else:
-                # We reached the beginning of the dataset; nothing left to yield
-                intervalObj = None
-
-        # If there's one last interval to the left, beyond the begin boundary,
-        # yield its metadata for beyond-the-scope drawing
-        if intervalObj is not None and 'lastParentInterval' in intervalObj:
+        if 'lastParentInterval' not in intervalObj and intervalObj['leave']['Timestamp'] >= begin:
+            # We ran out of intervals, and the last one was in range; just yield
+            # its id (no beyondLeft metadata needed)
+            yield ',"%s"' % intervalObj['intervalId']
+        elif lastInterval and lastInterval['leave']['Timestamp'] >= begin:
+            # Yield some metadata about the interval beyond the begin boundary,
+            # so the client can draw lines beyond the window (and won't need
+            # access to the interval itself)
             yield ',' + json.dumps({
                 'type': 'beyondLeft',
-                'id': intervalObj['lastParentInterval']['id'],
-                'location': intervalObj['lastParentInterval']['location'],
-                'endTimestamp': intervalObj['lastParentInterval']['endTimestamp']
+                'id': intervalObj['intervalId'],
+                'location': intervalObj['Location'],
+                'endTimestamp': intervalObj['leave']['Timestamp']
             })
-            yield ',"%s"' % intervalObj['intervalId']
 
+        # Finished
         yield ']'
     return StreamingResponse(intervalIdGenerator(), media_type='application/json')
 

--- a/static/controller.js
+++ b/static/controller.js
@@ -42,9 +42,11 @@ class Controller {
       // URL is telling us to navigate to a specific one
       this.attemptedAutoHashOpen = true;
       const hashedLabel = window.decodeURIComponent(window.location.hash).substring(1);
-      const state = this.getLinkedState(hashedLabel);
-      if (state) {
-        this.assembleViews(state);
+      if (hashedLabel) {
+        const state = this.getLinkedState(hashedLabel);
+        if (state) {
+          this.assembleViews(state);
+        }
       }
     }
   }

--- a/static/views/GanttView/GanttView.js
+++ b/static/views/GanttView/GanttView.js
@@ -258,30 +258,9 @@ class GanttView extends CursoredViewMixin(SvgViewMixin(LinkedMixin(GoldenLayoutV
     this.drawLinks(linkData);
   }
   getLinkData (intervals) {
-    let traceback;
-    // Combine old and new data, only if the target is the same as the last time
-    // that we fetched data
-    if (this.newTracebackCache !== null &&
-        this.linkedState.selectedIntervalId !== null &&
-        this.linkedState.selectedIntervalId === this.lastTracebackTarget) {
-      // Combine the list of visibleIds, but only include the left / right
-      // endpoints of newTracebackCache (in the event that the target interval
-      // was just scrolled back into view, don't draw any lines beyond it)
-      traceback = {
-        visibleIds: this.newTracebackCache.visibleIds.length > this.tracebackCache.visibleIds.length
-          ? this.newTracebackCache.visibleIds : this.tracebackCache.visibleIds,
-        leftEndpoint: this.newTracebackCache.leftEndpoint,
-        rightEndpoint: this.newTracebackCache.rightEndpoint
-      };
-    } else if (this.newTracebackCache !== null) {
-      // Need to make a copy, because otherwise this.drawLinks() could
-      // potentially mutate this.newTracebackCache
-      traceback = Object.assign({}, this.newTracebackCache);
-    } else {
-      // Need to make a copy, because otherwise this.drawLinks() could
-      // potentially mutate this.tracebackCache
-      traceback = Object.assign({}, this.tracebackCache);
-    }
+    // Make a copy of the newest available cache, because otherwise
+    // this.drawLinks() could potentially mutate the original
+    const traceback = Object.assign({}, this.newTracebackCache || this.tracebackCache);
 
     // Derive a list of intervals from the streamed list of IDs
     let linkData = [];
@@ -300,7 +279,7 @@ class GanttView extends CursoredViewMixin(SvgViewMixin(LinkedMixin(GoldenLayoutV
     if (linkData.length > 0) {
       if (traceback.rightEndpoint) {
         // Construct a fake "interval" for the right endpoint, because we draw
-        // lines to the left
+        // lines to the left (linkData is right-to-left)
         const parent = linkData[0];
         linkData.unshift({
           intervalId: traceback.rightEndpoint.id,
@@ -315,7 +294,7 @@ class GanttView extends CursoredViewMixin(SvgViewMixin(LinkedMixin(GoldenLayoutV
       }
       if (traceback.leftEndpoint) {
         // Copy the important parts of the leftmost interval object, overriding
-        // lastParentInterval (remember the order is right-to-left)
+        // lastParentInterval (linkData is right-to-left)
         const firstInterval = linkData[linkData.length - 1];
         linkData[linkData.length - 1] = {
           intervalId: firstInterval.intervalId,

--- a/static/views/GanttView/GanttView.js
+++ b/static/views/GanttView/GanttView.js
@@ -440,30 +440,36 @@ class GanttView extends CursoredViewMixin(SvgViewMixin(LinkedMixin(GoldenLayoutV
       }
     }
 
-    if (traceback.leftEndpoint && linkData.length > 0) {
-      // Copy the important parts of the first interval object, overriding
-      // lastParentInterval
-      linkData[0] = {
-        intervalId: linkData[0].intervalId,
-        Location: linkData[0].Location,
-        enter: { Timestamp: linkData[0].enter.Timestamp },
-        lastParentInterval: traceback.leftEndpoint
-      };
-    }
-    if (traceback.rightEndpoint && linkData.length > 0) {
-      // Construct a fake "interval" for the right endpoint, because we draw
-      // lines to the left
-      const parent = linkData[linkData.length - 1];
-      linkData.push({
-        intervalId: traceback.rightEndpoint.id,
-        Location: traceback.rightEndpoint.location,
-        enter: { Timestamp: traceback.rightEndpoint.beginTimestamp },
-        lastParentInterval: {
-          id: parent.intervalId,
-          endTimestamp: parent.leave.Timestamp,
-          location: parent.Location
-        }
-      });
+    if (linkData.length > 0) {
+      if (traceback.leftEndpoint && linkData.length > 0) {
+        // Copy the important parts of the first interval object, overriding
+        // lastParentInterval
+        linkData[0] = {
+          intervalId: linkData[0].intervalId,
+          Location: linkData[0].Location,
+          enter: { Timestamp: linkData[0].enter.Timestamp },
+          lastParentInterval: traceback.leftEndpoint
+        };
+      } else if (!linkData[linkData.length - 1].lastParentInterval) {
+        // In cases where an interval with no parent is at the beginning of the
+        // traceback, there's no line to draw to the left; we can just omit it
+        linkData.splice(-1);
+      }
+      if (traceback.rightEndpoint && linkData.length > 0) {
+        // Construct a fake "interval" for the right endpoint, because we draw
+        // lines to the left
+        const parent = linkData[linkData.length - 1];
+        linkData.push({
+          intervalId: traceback.rightEndpoint.id,
+          Location: traceback.rightEndpoint.location,
+          enter: { Timestamp: traceback.rightEndpoint.beginTimestamp },
+          lastParentInterval: {
+            id: parent.intervalId,
+            endTimestamp: parent.leave.Timestamp,
+            location: parent.Location
+          }
+        });
+      }
     }
 
     let links = this.content.select('.links')

--- a/static/views/GanttView/GanttView.js
+++ b/static/views/GanttView/GanttView.js
@@ -441,21 +441,6 @@ class GanttView extends CursoredViewMixin(SvgViewMixin(LinkedMixin(GoldenLayoutV
     }
 
     if (linkData.length > 0) {
-      if (traceback.leftEndpoint) {
-        // Copy the important parts of the leftmost interval object, overriding
-        // lastParentInterval (remember the order is right-to-left)
-        const firstInterval = linkData[linkData.length - 1];
-        linkData[linkData.length - 1] = {
-          intervalId: firstInterval.intervalId,
-          Location: firstInterval.Location,
-          enter: { Timestamp: firstInterval.enter.Timestamp },
-          lastParentInterval: traceback.leftEndpoint
-        };
-      } else if (!linkData[linkData.length - 1].lastParentInterval) {
-        // In cases where an interval with no parent is at the beginning of the
-        // traceback, there's no line to draw to the left; we can just omit it
-        linkData.splice(-1);
-      }
       if (traceback.rightEndpoint) {
         // Construct a fake "interval" for the right endpoint, because we draw
         // lines to the left
@@ -470,6 +455,21 @@ class GanttView extends CursoredViewMixin(SvgViewMixin(LinkedMixin(GoldenLayoutV
             location: parent.Location
           }
         });
+      }
+      if (traceback.leftEndpoint) {
+        // Copy the important parts of the leftmost interval object, overriding
+        // lastParentInterval (remember the order is right-to-left)
+        const firstInterval = linkData[linkData.length - 1];
+        linkData[linkData.length - 1] = {
+          intervalId: firstInterval.intervalId,
+          Location: firstInterval.Location,
+          enter: { Timestamp: firstInterval.enter.Timestamp },
+          lastParentInterval: traceback.leftEndpoint
+        };
+      } else if (!linkData[linkData.length - 1].lastParentInterval) {
+        // In cases where an interval with no parent is at the beginning of the
+        // traceback, there's no line to draw to the left; we can just omit it
+        linkData.splice(-1);
       }
     }
 

--- a/static/views/GanttView/GanttView.js
+++ b/static/views/GanttView/GanttView.js
@@ -92,7 +92,7 @@ class GanttView extends CursoredViewMixin(SvgViewMixin(LinkedMixin(GoldenLayoutV
       // necessitate requesting a longer traceback; ideally changing the selected
       // interval shouldn't trigger a full data request. Maybe the selection
       // interaction could be faster if we did this separately?
-      if (this.linkedState.selectedIntervalId === undefined) {
+      if (!this.linkedState.selectedIntervalId) {
         this.tracebackStream = null;
         this.tracebackCache = {
           visibleIds: [],
@@ -238,7 +238,8 @@ class GanttView extends CursoredViewMixin(SvgViewMixin(LinkedMixin(GoldenLayoutV
     // Do the same with the traceback, but only if the target is the same as
     // the last time that we fetched data
     let traceback;
-    if (this.linkedState.selectedIntervalId === this.lastTracebackTarget) {
+    if (this.linkedState.selectedIntervalId !== null &&
+        this.linkedState.selectedIntervalId === this.lastTracebackTarget) {
       // Combine the list of visibleIds, but only include the left / right
       // endpoints of newTracebackCache (in the event that the target interval
       // was just scrolled back into view, don't draw any lines beyond it)
@@ -248,10 +249,14 @@ class GanttView extends CursoredViewMixin(SvgViewMixin(LinkedMixin(GoldenLayoutV
         leftEndpoint: this.newTracebackCache.leftEndpoint,
         rightEndpoint: this.newTracebackCache.rightEndpoint
       };
-    } else {
+    } else if (this.newTracebackCache !== null) {
       // Need to make a copy, because otherwise this.drawLinks() could
       // potentially mutate this.newTracebackCache
       traceback = Object.assign({}, this.newTracebackCache);
+    } else {
+      // Need to make a copy, because otherwise this.drawLinks() could
+      // potentially mutate this.tracebackCache
+      traceback = Object.assign({}, this.tracebackCache);
     }
 
     // Update whether we're showing the spinner

--- a/static/views/GanttView/GanttView.js
+++ b/static/views/GanttView/GanttView.js
@@ -441,13 +441,14 @@ class GanttView extends CursoredViewMixin(SvgViewMixin(LinkedMixin(GoldenLayoutV
     }
 
     if (linkData.length > 0) {
-      if (traceback.leftEndpoint && linkData.length > 0) {
-        // Copy the important parts of the first interval object, overriding
-        // lastParentInterval
-        linkData[0] = {
-          intervalId: linkData[0].intervalId,
-          Location: linkData[0].Location,
-          enter: { Timestamp: linkData[0].enter.Timestamp },
+      if (traceback.leftEndpoint) {
+        // Copy the important parts of the leftmost interval object, overriding
+        // lastParentInterval (remember the order is right-to-left)
+        const firstInterval = linkData[linkData.length - 1];
+        linkData[linkData.length - 1] = {
+          intervalId: firstInterval.intervalId,
+          Location: firstInterval.Location,
+          enter: { Timestamp: firstInterval.enter.Timestamp },
           lastParentInterval: traceback.leftEndpoint
         };
       } else if (!linkData[linkData.length - 1].lastParentInterval) {
@@ -455,11 +456,11 @@ class GanttView extends CursoredViewMixin(SvgViewMixin(LinkedMixin(GoldenLayoutV
         // traceback, there's no line to draw to the left; we can just omit it
         linkData.splice(-1);
       }
-      if (traceback.rightEndpoint && linkData.length > 0) {
+      if (traceback.rightEndpoint) {
         // Construct a fake "interval" for the right endpoint, because we draw
         // lines to the left
-        const parent = linkData[linkData.length - 1];
-        linkData.push({
+        const parent = linkData[0];
+        linkData.unshift({
           intervalId: traceback.rightEndpoint.id,
           Location: traceback.rightEndpoint.location,
           enter: { Timestamp: traceback.rightEndpoint.beginTimestamp },

--- a/static/views/GanttView/style.less
+++ b/static/views/GanttView/style.less
@@ -47,6 +47,7 @@
       stroke-width: 1px;
       stroke: black; /* TODO: Unify me */
       vector-effect: non-scaling-stroke;
+      pointer-events: none;
     }
   }
 }

--- a/static/views/LineChartView/LineChartView.js
+++ b/static/views/LineChartView/LineChartView.js
@@ -1,0 +1,534 @@
+/* globals d3, oboe */
+import GoldenLayoutView from '../common/GoldenLayoutView.js';
+import LinkedMixin from '../common/LinkedMixin.js';
+import SvgViewMixin from '../common/SvgViewMixin.js';
+import CursoredViewMixin from '../common/CursoredViewMixin.js';
+import normalizeWheel from '../../utils/normalize-wheel.js';
+import cleanupAxis from '../../utils/cleanupAxis.js';
+
+class LineChartView extends CursoredViewMixin(SvgViewMixin(LinkedMixin(GoldenLayoutView))) {
+  constructor (argObj) {
+    argObj.resources = [
+      { type: 'less', url: 'views/LineChartView/style.less' },
+      { type: 'text', url: 'views/LineChartView/template.svg' }
+    ];
+    super(argObj);
+    this.xScale = d3.scaleLinear();
+    this.yScale = d3.scaleLinear();
+
+    this.stream = null;
+    this.cache = {};
+    this.newCache = null;
+    this.intervalCount = 0;
+    this.curMetric = 'PAPI_TOT_CYC';
+    this.selectedLocation = "-1";
+    this.baseOpacity = 0.3;
+    // Don't bother drawing bars if there are more than 10000 visible intervals
+    this.renderCutoff = 10000;
+
+    // Override uki's default .1 second debouncing of render() because we want
+    // to throttle incremental updates to at most once per second
+    this.debounceWait = 1000;
+
+    // Some things like SVG clipPaths require ids instead of classes...
+    this.uniqueDomId = `LineChartView${LineChartView.DOM_COUNT}`;
+    LineChartView.DOM_COUNT++;
+  }
+  getData () {
+    // Debounce the start of this expensive process...
+    // (but flag that we're loading)
+    window.clearTimeout(this._resizeTimeout);
+    this._resizeTimeout = window.setTimeout(async () => {
+      const label = encodeURIComponent(this.layoutState.label);
+      const intervalWindow = this.linkedState.intervalWindow;
+      const self = this;
+      // First check whether we're asking for too much data by getting a
+      // histogram with a single bin (TODO: draw per-location histograms instead
+      // of just saying "Too much data; scroll to zoom in?")
+      const curLocation = 1;
+      var binSize = 100;
+      binSize = parseInt(binSize, 10);
+      this.histogram = await d3.json(`/datasets/${label}/metrichistogram?bins=1&location=${curLocation}&mode=count&begin=${intervalWindow[0]}&end=${intervalWindow[1]}`);
+      this.intervalCount = this.histogram[0][2];
+      console.log("metric histogram count: " + this.intervalCount);
+      if (this.isEmpty) {
+        // Empty out whatever we were looking at before and bail immediately
+        this.stream = null;
+        this.cache = {};
+        this.newCache = null;
+        this.render();
+        return;
+      }
+
+      // Okay, start the stream, and collect it in a separate cache to avoid
+      // old intervals from disappearing from incremental refreshes
+      this.newCache = {};
+      this.waitingOnIncrementalRender = false;
+      var maxY = 0;
+      var preX = 0, preT = 0, curX = 0, curT = 0, rt = 0;
+      var locationPosition = {};
+      const currentStream = this.stream = oboe(`/datasets/${label}/metrices?begin=${intervalWindow[0]}&end=${intervalWindow[1]}`)
+      // const currentStream = this.stream = oboe(`/datasets/${label}/metrichistogram?bins=${binSize}&metric=${curMetric}&location=${curLocation}&mode=count&begin=${intervalWindow[0]}&end=${intervalWindow[1]}`)
+          .fail(error => {
+            this.error = error;
+            console.log(error);
+          })
+          .node('!.*', function (interval) {
+            if (currentStream !== self.stream) {
+              // A different stream has been started; abort this one
+              this.abort();
+            } else {
+              const key = interval.timestamp + '_' + interval.location;
+              self.newCache[key] = interval;
+
+              curX = interval[self.curMetric];
+              curT = interval.timestamp;
+              if(interval.location in locationPosition && locationPosition[interval.location][0] > -1) {
+                rt = Math.abs(curX - locationPosition[interval.location][0]) / Math.abs(curT - locationPosition[interval.location][1]);
+              } else {
+                locationPosition[interval.location] = [-1,-1];
+                rt = curX/curT;
+              }
+              locationPosition[interval.location][0] = curX;
+              locationPosition[interval.location][1] = curT;
+              maxY = Math.max(maxY, rt);
+
+              if (!self.waitingOnIncrementalRender) {
+                // self.render() is debounced; this converts it to throttling,
+                // rate-limiting incremental refreshes by this.debounceWait
+                self.render();
+                self.waitingOnIncrementalRender = true;
+              }
+            }
+          })
+          .done(() => {
+            this.stream = null;
+            this.cache = this.newCache;
+            this.newCache = null;
+            console.log("y updated: " + maxY);
+            this.yScale.domain([maxY+1, 0]);
+            this.render();
+          });
+      this.yScale.domain([maxY+1, 0]);
+      this.render();
+    }, 100);
+  }
+  get isLoading () {
+    return super.isLoading || this.stream !== null;
+  }
+  get isEmpty () {
+    return this.error || this.intervalCount === 0 || this.intervalCount > this.renderCutoff;
+  }
+  getChartBounds () {
+    const bounds = this.getAvailableSpace();
+    const result = {
+      width: bounds.width - this.margin.left - this.margin.right,
+      height: bounds.height - this.margin.top - this.margin.bottom,
+      left: bounds.left + this.margin.left,
+      top: bounds.top + this.margin.top,
+      right: bounds.right - this.margin.right,
+      bottom: bounds.bottom - this.margin.bottom
+    };
+    this.xScale.range([0, result.width]);
+    this.yScale.range([0, result.height]);
+    return result;
+  }
+  setup () {
+    super.setup();
+
+    this.content.html(this.resources[1]);
+
+    this.margin = {
+      top: 20,
+      right: 20,
+      bottom: 40,
+      left: 40
+    };
+    this.content.select('.chart')
+        .attr('transform', `translate(${this.margin.left},${this.margin.top})`);
+
+    // Create a view-specific clipPath id, as there can be more than one
+    // LineChartView in the app
+    const clipId = this.uniqueDomId + 'clip';
+    this.content.select('clipPath')
+        .attr('id', clipId);
+    this.content.select('.clippedStuff')
+        .attr('clip-path', `url(#${clipId})`);
+
+    // Set up zoom / pan interactions
+    this.setupZoomAndPan();
+
+    // Update scales whenever something changes the brush
+    this.linkedState.on('newIntervalWindow', () => {
+      this.xScale.domain(this.linkedState.intervalWindow);
+      // this.yScale.domain([200, 100]);
+      // Abort + re-start the stream
+      this.getData();
+    });
+    // Initialize the scales / stream
+    this.xScale.domain(this.linkedState.intervalWindow);
+    // this.yScale.domain([200, 100]);
+    this.getData();
+
+    // Draw the axes right away (because we have a longer debounceWait than
+    // normal, there's an initial ugly flash before draw() gets called)
+    this._bounds = this.getChartBounds();
+    this.drawAxes();
+
+    // Redraw when a new primitive is selected
+    // TODO: can probably do this immediately in a more light-weight way?
+    this.linkedState.on('primitiveSelected', () => { this.render(); });
+
+    this.content.select('.background')
+        .on('click', () => {
+          this.selectedLocation = "-1";
+          this.render();
+        });
+  }
+  draw () {
+    super.draw();
+
+    if (this.isHidden) {
+      return;
+    } else if (this.isEmpty) {
+      if (this.error) {
+        this.emptyStateDiv.html(`<p>Error communicating with the server</p>`);
+      } else if (this.intervalCount === 0) {
+        this.emptyStateDiv.html('<p>No data in the current view</p>');
+      } else {
+        this.emptyStateDiv.html('<p>Too much data; scroll to zoom in</p>');
+      }
+    }
+    // Update the dimensions of the plot in case we were resized (NOT updated by
+    // immediately-drawn things like drawAxes that get executed repeatedly by
+    // scrolling / panning)
+    this._bounds = this.getChartBounds();
+
+    // Combine old data with any new data that's streaming in
+    const data = d3.entries(Object.assign({}, this.cache, this.newCache || {}));
+
+    // Hide the small spinner
+    this.content.select('.small.spinner').style('display', 'none');
+    // Update the clip rect
+    this.drawClip();
+    // Update the axes (also updates scales)
+    this.drawAxes();
+
+    // if (this.linkedState.selectedIntervalId) {
+    //   // This is partial clone code from drawLinks
+    //   // Collect only the links in the back-path of the selected IntervalId
+    //   // TODO Make me more efficient, this has a lot of passes
+    //   let workingId = this.linkedState.selectedIntervalId;
+    //   let inView = true;
+    //   while (inView) {
+    //     let interval = data.find(d => d.value.intervalId === workingId);
+    //
+    //     // Only continue if interval is found and has a link backwards
+    //     if (interval && interval.value.hasOwnProperty('lastParentInterval')) {
+    //       interval.value.inTraceBack = true;
+    //     } else {
+    //       inView = false;
+    //       continue;
+    //     }
+    //
+    //     workingId = interval.value.lastParentInterval.id;
+    //     // Only continue if previous interval is drawn
+    //     if (interval.value.lastParentInterval.endTimestamp < this.xScale.range()[0]) {
+    //       inView = false;
+    //     }
+    //   }
+    // } else {
+    //   data.map(d => { d.value.inTraceBack = false; return d; });
+    // }
+
+    // Update the bars
+    this.drawLines(data);
+    // Update the links
+    // this.drawLinks(data);
+
+    // Update the incremental flag so that we can call render again if needed
+    this.waitingOnIncrementalRender = false;
+  }
+  drawClip () {
+    this.content.select('clipPath rect')
+        .attr('width', this._bounds.width)
+        .attr('height', this._bounds.height);
+  }
+  drawAxes () {
+    const bounds = this.getChartBounds();
+    // Update the x axis
+    const xAxisGroup = this.content.select('.xAxis')
+        .attr('transform', `translate(0, ${this._bounds.height})`)
+        .call(d3.axisBottom(this.xScale));
+    cleanupAxis(xAxisGroup);
+
+    // Position the x label
+    this.content.select('.xAxisLabel')
+        .attr('x', this._bounds.width / 2)
+        .attr('y', this._bounds.height + this.margin.bottom - this.emSize / 2);
+
+    // Update the y axis
+    this.content.select('.yAxis')
+        .call(d3.axisLeft(this.yScale));
+
+    // Position the y label
+    this.content.select('.yAxisLabel')
+        .attr('transform', `translate(${-1.5 * this.emSize},${bounds.height / 2}) rotate(-90)`);
+  }
+  drawLines (data) {
+    console.log("drawing again");
+    var _self = this;
+    var locationPosition = {};
+    var timePosition = {};
+    var ratePosition = {};
+    if (!this.initialDragState) {
+      // Remove temporarily patched transformations
+      this.content.select('.dots').attr('transform', null);
+    }
+
+    let cirlces = this.content.select('.dots')
+        .selectAll('.dot').data(data, d => d.key);
+    cirlces.exit().remove();
+    const cirlcesEnter = cirlces.enter().append('circle')
+        .classed('dot', true);
+    cirlces = cirlces.merge(cirlcesEnter);
+
+    var calcRate = function (d, i) {
+      if(d.value.location in locationPosition) {
+        //do nothing
+      } else {
+        locationPosition[d.value.location] = [-1, -1];
+      }
+      var Xi = 0;
+      var Ti  = 0;
+      if(locationPosition[d.value.location][0] > -1) {
+        var dd = cirlces.data()[locationPosition[d.value.location][0]];
+        Xi = dd.value[_self.curMetric];
+        Ti = dd.value.timestamp;
+      }
+      var Xj = d.value[_self.curMetric];
+      var Tj = d.value.timestamp;
+      if(locationPosition[d.value.location][1] == -1 && Xi == Xj) {
+        Xi = 0; Ti = 0;
+      }
+      var ret = Math.abs(Xj - Xi) / Math.abs(Tj - Ti);
+
+      var Xh = 0;
+      var Th = 0;
+      if(locationPosition[d.value.location][1] > -1) {
+        var pred = cirlces.data()[locationPosition[d.value.location][1]];
+        Xh = pred.value[_self.curMetric];
+        Th = pred.value.timestamp;
+        ret += Math.abs(Xi - Xh) / Math.abs(Ti - Th);
+      }
+      locationPosition[d.value.location][1] = locationPosition[d.value.location][0];
+      locationPosition[d.value.location][0] = i;
+      return ret;
+    };
+
+    cirlces.attr('class','dot')
+        .attr('cx', d => this.xScale(d.value.timestamp))
+        .attr('cy', function (d, i) {
+          return _self.yScale(calcRate(d, i));
+        })
+        .attr('r', d => {
+          if (d.value.location === _self.selectedLocation) {
+            return 2.0;
+          }
+          return 1.0;
+        })
+        .style('opacity', d => {
+          if (d.value.location === _self.selectedLocation) {
+            return 1.0;
+          }
+          return _self.baseOpacity;
+        });
+
+    locationPosition = {};
+
+    let lines = this.content.select('.lines')
+        .selectAll('.line').data(data, d => d.key);
+    lines.exit().remove();
+    const linesEnter = lines.enter().append('line')
+        .classed('line', true);
+    lines = lines.merge(linesEnter);
+
+    lines.attr('class','line')
+        .attr('x1', function(d,i){
+          if(d.value.location in timePosition) {
+            var prevData = lines.data()[timePosition[d.value.location]];
+            timePosition[d.value.location] = i;
+            return _self.xScale(prevData.value.timestamp);
+          } else {
+            timePosition[d.value.location] = i;
+          }
+          return _self.xScale(0);
+        })
+        .attr('y1', function(d,i){
+          if(d.value.location in ratePosition) {
+            var prevData = lines.data()[ratePosition[d.value.location]];
+            var retVal = _self.yScale(calcRate(prevData, ratePosition[d.value.location]));
+            ratePosition[d.value.location] = i;
+            return retVal;
+          } else {
+            ratePosition[d.value.location] = i;
+          }
+          return _self.yScale(0);
+        })
+        .attr('x2', function(d,i){
+          return _self.xScale(d.value.timestamp);
+        })
+        .attr('y2', function(d,i){
+          if(i===0) {
+            locationPosition = {};
+          }
+          return _self.yScale(calcRate(d, i));
+        })
+        .style('stroke', d => {
+          if (d.value.location === _self.selectedLocation) {
+            return 'blue';
+          }
+          return 'black';
+        })
+        .style('stroke-width', 3)
+        .style('opacity', d => {
+          if (d.value.location === _self.selectedLocation) {
+            return 1.0;
+          }
+          return _self.baseOpacity;
+        })
+        .on('mouseenter', function (d) {
+          window.controller.tooltip.show({
+            content: `<pre>${JSON.stringify(d.value, null, 2)}</pre>`,
+            targetBounds: this.getBoundingClientRect(),
+            hideAfterMs: null
+          });
+        })
+        .on("mouseout", () => {
+          window.controller.tooltip.hide();
+        })
+        .on('click', (d) => {
+          this.selectedLocation = d.value.location;
+          console.log("clicked " + this.selectedLocation);
+          this.render();
+        });
+        // .on('mousedown', function(d) {
+        //   console.log("mousedown");
+        // })
+        // .on('mouseup', function(d) {
+        //   console.log("mouseup");
+        // })
+    // lines.select('.line')
+    //     .style('opacity', d => {
+    //       if (_self.selectedLocation !== "-1" && d.value.location === _self.selectedLocation) {
+    //         return 1.0;
+    //       }
+    //       return 0.1;
+    //     });
+
+  }
+  setupZoomAndPan () {
+    this.initialDragState = null;
+    let latentWidth = null;
+    const clampWindow = (begin, end) => {
+      // clamp to the lowest / highest possible values
+      if (begin <= this.linkedState.beginLimit) {
+        const offset = this.linkedState.beginLimit - begin;
+        begin += offset;
+        end += offset;
+      }
+      if (end >= this.linkedState.endLimit) {
+        const offset = end - this.linkedState.endLimit;
+        begin -= offset;
+        end -= offset;
+      }
+      return { begin, end };
+    };
+    this.content
+        .on('wheel', () => {
+          const zoomFactor = 1.05 ** (normalizeWheel(d3.event).pixelY / 100);
+          const originalWidth = this.linkedState.end - this.linkedState.begin;
+          // Clamp the width to a min of 10ms, and the largest possible size
+          let targetWidth = Math.max(zoomFactor * originalWidth, 10);
+          targetWidth = Math.min(targetWidth, this.linkedState.endLimit - this.linkedState.beginLimit);
+          // Compute the new begin / end points, centered on where the user is mousing
+          const mousedScreenPoint = d3.event.clientX - this._bounds.left - this.margin.left;
+          const mousedPosition = this.xScale.invert(mousedScreenPoint);
+          const begin = mousedPosition - (targetWidth / originalWidth) * (mousedPosition - this.linkedState.begin);
+          const end = mousedPosition + (targetWidth / originalWidth) * (this.linkedState.end - mousedPosition);
+          const actualBounds = clampWindow(begin, end);
+
+          // There isn't a begin / end wheel event, so trigger the update across
+          // views immediately
+          this.linkedState.setIntervalWindow(actualBounds);
+
+          // For responsiveness, draw the axes immediately (the debounced, full
+          // render() triggered by changing linkedState may take a while)
+          this.drawAxes();
+
+          // Patch a temporary scale transform to the bars / links layers (this
+          // gets removed by full drawBars() / drawLinks() calls)
+          if (!this.content.select('.dots').attr('transform')) {
+            latentWidth = originalWidth;
+          }
+          const actualZoomFactor = latentWidth / (actualBounds.end - actualBounds.begin);
+          const zoomCenter = (1 - actualZoomFactor) * mousedScreenPoint;
+          this.content.selectAll('.dots')
+              .attr('transform', `translate(${zoomCenter}, 0) scale(${actualZoomFactor}, 1)`);
+          // Show the small spinner to indicate that some of the stuff the user
+          // sees may be inaccurate (will be hidden once the full draw() call
+          // happens)
+          this.content.select('.small.spinner').style('display', null);
+        }).call(d3.drag()
+        .on('start', () => {
+          this.initialDragState = {
+            begin: this.linkedState.begin,
+            end: this.linkedState.end,
+            x: this.xScale.invert(d3.event.x),
+            scale: d3.scaleLinear()
+                .domain(this.xScale.domain())
+                .range(this.xScale.range())
+          };
+        })
+        .on('drag', () => {
+          const mousedPosition = this.initialDragState.scale.invert(d3.event.x);
+          const dx = this.initialDragState.x - mousedPosition;
+          const begin = this.initialDragState.begin + dx;
+          const end = this.initialDragState.end + dx;
+          const actualBounds = clampWindow(begin, end);
+          // Don't bother triggering a full update mid-drag...
+          // this.linkedState.setIntervalWindow(actualBounds)
+
+          // For responsiveness, draw the axes immediately (the debounced, full
+          // render() triggered by changing linkedState may take a while)
+          this.drawAxes();
+
+          // Patch a temporary translation to the bars / links layers (this gets
+          // removed by full drawBars() / drawLinks() calls)
+          const shift = this.initialDragState.scale(this.initialDragState.begin) -
+              this.initialDragState.scale(actualBounds.begin);
+          this.content.selectAll('.dots')
+              .attr('transform', `translate(${shift}, 0)`);
+
+          // Show the small spinner to indicate that some of the stuff the user
+          // sees may be inaccurate (will be hidden once the full draw() call
+          // happens)
+          this.content.select('.small.spinner').style('display', null);
+
+          // d3's drag behavior captures + prevents updating the cursor, so do
+          // that manually
+          this.linkedState.moveCursor(mousedPosition);
+          this.updateCursor();
+        })
+        .on('end', () => {
+          const dx = this.initialDragState.x - this.initialDragState.scale.invert(d3.event.x);
+          const begin = this.initialDragState.begin + dx;
+          const end = this.initialDragState.end + dx;
+          this.initialDragState = null;
+
+          this.linkedState.setIntervalWindow(clampWindow(begin, end));
+        }));
+  }
+}
+LineChartView.DOM_COUNT = 1;
+export default LineChartView;

--- a/static/views/LineChartView/style.less
+++ b/static/views/LineChartView/style.less
@@ -1,0 +1,52 @@
+@import '../../style/colors.less';
+
+.LineChartView {
+  cursor: grab;
+  touch-action: none; /* Don't zoom the browser when the user pinches */
+  &:active {
+    cursor: grabbing;
+  }
+  text {
+    font: 9px sans-serif;
+  }
+  .background rect {
+    fill: transparent;
+  }
+  .cursor {
+    stroke-width: 1px;
+    stroke: @separatorColor;
+  }
+  .yAxis line {
+    stroke-weight: 1px;
+    stroke: @separatorColor;
+  }
+
+  .bar {
+    cursor: pointer;
+    .outline {
+      fill: none;
+      stroke-width: 1px;
+      stroke: @overviewColor;
+      vector-effect: non-scaling-stroke;
+    }
+    .area {
+      stroke: none;
+      opacity: 0.25;
+      fill: @overviewColor;
+    }
+    &:hover {
+      .area { opacity: 0.5; }
+    }
+    .traceback {
+      stroke: black;
+    }
+  }
+
+  .lines {
+    .line {
+      stroke-width: 1px;
+      stroke: black; /* TODO: Unify me */
+      vector-effect: non-scaling-stroke;
+    }
+  }
+}

--- a/static/views/LineChartView/template.svg
+++ b/static/views/LineChartView/template.svg
@@ -1,0 +1,20 @@
+<defs>
+  <clipPath id="dummy">
+    <rect></rect>
+  </clipPath>
+</defs>
+<g class="chart">
+  <g class="background">
+    <rect></rect>
+    <image class="small spinner" style="display:none" x="-30" y="-10" width="20" height="20" xlink:href="img/spinner.gif"></image>
+    <line class="cursor" style="display:none"></line>
+    <g class="yAxis"></g>
+    <text class="yAxisLabel" text-anchor="middle">Rate</text>
+    <g class="xAxis"></g>
+    <text class="xAxisLabel" text-anchor="middle">Time in Nanoseconds</text>
+  </g>
+  <g class="clippedStuff">
+    <g class="dots"></g>
+    <g class="lines"></g>
+  </g>
+</g>


### PR DESCRIPTION
Sorry this took so long; I've migrated all the data collection for intervals (as well as the utilization histogram) to `static/models/LinkedState.js` ... this way, you shouldn't even need a `getData()` call in `LineChartView.js`. Instead, you can do things like `this.linkedState.getCurrentIntervals()` and listen for `this.linkedState.on('intervalStreamFinished', () => { this.render(); }`... the model should now be responsible for worrying about when to fetch new data (in response to things like `this.linkedState.setIntervalWindow`).

The metric data has been moved to the interval objects, so you shouldn't need to ask the server for them anymore (and bundling data is **much** faster—thanks for this suggestion!):

![image](https://user-images.githubusercontent.com/1215873/70743866-de3b4d80-1cdd-11ea-81f3-3d8849f09b2a.png)

Like other attributes, if there's ever a discrepancy between ENTER vs LEAVE metrics, the `metrics: {}` object will be moved inside the `enter: {}` / `leave: {}` objects.

I've copied your LineChartView verbatim—if there are any issues or confusion getting it to work, please don't hesitate to ask.